### PR TITLE
Use correct machine-readable copyright file URI

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+fbset (2.1-33) UNRELEASED; urgency=medium
+
+  * Use correct machine-readable copyright file URI.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 25 Apr 2020 06:00:20 +0000
+
 fbset (2.1-32) unstable; urgency=medium
 
   * Update Standards-Version to 4.5.0

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Contact: Geert Uytterhoeven <geert@linux-m68k.org>
 Source: http://users.telenet.be/geertu/Linux/fbdev/
 Comment:


### PR DESCRIPTION
Use correct machine-readable copyright file URI. ([out-of-date-copyright-format](https://lintian.debian.org/tags/out-of-date-copyright-format.html))

This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/fbset/58b4bafe-8720-4a00-a284-94d57f51b8c4.
