### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 fbset (2.1-33) UNRELEASED; urgency=medium
 
   * Use correct machine-readable copyright file URI.
+  * Remove constraints unnecessary since stretch:
+    + fbset: Drop versioned constraint on makedev in Depends.
 
  -- Debian Janitor <janitor@jelmer.uk>  Sat, 25 Apr 2020 06:00:20 +0000
 

--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Architecture: linux-any
 Depends:
  ${misc:Depends},
  ${shlibs:Depends},
- udev | makedev (>= 2.3.1-24),
+ udev | makedev
 Description: framebuffer device maintenance program
  Program to modify settings for the framebuffer devices (/dev/fb[0-9]*
  or /dev/fb/[0-9]*) on Linux, like depth, virtual resolution, timing


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/fbset/1474751e-2244-4af2-af76-70b6f6cd10e4.



## Debdiff

These changes affect the binary packages:


[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/83/9b1b9cd17624a76eb3240ab5270881fd53f632.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/b4/7bb80b3f584062807b30684d89e19bd07a3ea8.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/24/708d95fa6648a24c5a4c0caaebe7728662223a.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/4d/5842de31dbb0347989acd74c8c21b268c5a56f.debug
### Control files of package fbset: lines which differ (wdiff format)
* Depends: libc6 (>= 2.14), udev | makedev [-(>= 2.3.1-24)-]
### Control files of package fbset-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-24708d95fa6648a24c5a4c0caaebe7728662223a 4d5842de31dbb0347989acd74c8c21b268c5a56f-] {+839b1b9cd17624a76eb3240ab5270881fd53f632 b47bb80b3f584062807b30684d89e19bd07a3ea8+}

No differences were encountered between the control files of package \*\*fbset-udeb\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/1474751e-2244-4af2-af76-70b6f6cd10e4/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/1474751e-2244-4af2-af76-70b6f6cd10e4/diffoscope)).
