### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+fbset (2.1-34) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster (oldstable):
+    + Build-Depends: Drop dependency on essential package dpkg-dev (>= 1.15.7).
+    + fbset: Drop versioned constraint on makedev (>= 2.3.1-24) in Depends.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sat, 21 Jan 2023 01:53:18 -0000
+
 fbset (2.1-33) unstable; urgency=medium
 
   [ Debian Janitor ]

--- a/debian/control
+++ b/debian/control
@@ -7,14 +7,14 @@ Vcs-Browser: https://github.com/sudipm-mukherjee/fbset.git
 Vcs-Git: https://github.com/sudipm-mukherjee/fbset.git
 Standards-Version: 4.6.1.0
 Rules-Requires-Root: no
-Build-Depends: debhelper-compat (= 13), dpkg-dev (>= 1.15.7), flex, bison
+Build-Depends: debhelper-compat (= 13), flex, bison
 
 Package: fbset
 Architecture: linux-any
 Depends:
  ${misc:Depends},
  ${shlibs:Depends},
- udev | makedev (>= 2.3.1-24),
+ udev | makedev,
 Description: framebuffer device maintenance program
  Program to modify settings for the framebuffer devices (/dev/fb[0-9]*
  or /dev/fb/[0-9]*) on Linux, like depth, virtual resolution, timing


### PR DESCRIPTION
Remove unnecessary constraints.

## Debdiff

These changes affect the binary packages:

[The following lists of changes regard files as different if they have
different names, permissions or owners.]
### Files in second set of .debs but not in first
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/0e/b3471bcaebb7cf377636d5747f56f555279865.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/3d/8ffe627e806754b60879b9024113c5285913b2.debug
### Files in first set of .debs but not in second
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/10/47c9fb6bc7ec18c31e643026e47ccd484fb301.debug
    -rw-r--r--  root/root   /usr/lib/debug/.build-id/6d/58705a6669145c0f12497397310339633cbc1a.debug
### Control files of package fbset: lines which differ (wdiff format)
* Depends: libc6 (>= 2.34), udev | makedev [-(>= 2.3.1-24)-]
### Control files of package fbset-dbgsym: lines which differ (wdiff format)
* Build-Ids: [-1047c9fb6bc7ec18c31e643026e47ccd484fb301 6d58705a6669145c0f12497397310339633cbc1a-] {+0eb3471bcaebb7cf377636d5747f56f555279865 3d8ffe627e806754b60879b9024113c5285913b2+}
### Control files of package fbset-udeb: lines which differ (wdiff format)
* Depends: libc6-udeb (>= [-2.34)-] {+2.36)+}

You can also view the [diffoscope diff](https://janitor.debian.net/api/run/966ad13d-30b4-4c59-bc39-07e725b3bd06/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/966ad13d-30b4-4c59-bc39-07e725b3bd06/diffoscope)).

This merge proposal was created by the [Janitor bot](https://janitor.debian.net/scrub-obsolete), and it will automatically rebase or close this proposal as appropriate when the target branch changes. Any comments you leave here will be read by the Janitor's maintainers.

Build and test logs for this branch can be found at https://janitor.debian.net/scrub-obsolete/pkg/fbset/966ad13d-30b4-4c59-bc39-07e725b3bd06.